### PR TITLE
feat: allow multiple plugin proxies

### DIFF
--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -444,7 +444,7 @@ interface VendettaObject {
         PLUGINS_CHANNEL_ID: string;
         THEMES_CHANNEL_ID: string;
         GITHUB: string;
-        PROXY_PREFIX: array;
+        PROXY_PREFIX: string[];
         HTTP_REGEX: RegExp;
         HTTP_REGEX_MULTI: RegExp;
         ESCAPE_REGEX: RegExp;

--- a/src/def.d.ts
+++ b/src/def.d.ts
@@ -444,7 +444,7 @@ interface VendettaObject {
         PLUGINS_CHANNEL_ID: string;
         THEMES_CHANNEL_ID: string;
         GITHUB: string;
-        PROXY_PREFIX: string;
+        PROXY_PREFIX: array;
         HTTP_REGEX: RegExp;
         HTTP_REGEX_MULTI: RegExp;
         ESCAPE_REGEX: RegExp;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,7 +4,7 @@ export const DISCORD_SERVER_ID = "1015931589865246730";
 export const PLUGINS_CHANNEL_ID = "1091880384561684561";
 export const THEMES_CHANNEL_ID = "1091880434939482202";
 export const GITHUB = "https://github.com/revenge-mod";
-export const PROXY_PREFIX = "https://vd-plugins.github.io/proxy";
+export const PROXY_PREFIX = ["https://vd-plugins.github.io/proxy"];
 export const HTTP_REGEX = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/;
 export const HTTP_REGEX_MULTI = /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&//=]*)/g;
 export const ESCAPE_REGEX = /[.*+?^${}()|[\]\\]/g;

--- a/src/ui/quickInstall/url.tsx
+++ b/src/ui/quickInstall/url.tsx
@@ -17,7 +17,7 @@ const { getChannel } = findByProps("getChannel");
 const { TextStyleSheet } = findByProps("TextStyleSheet");
 
 function typeFromUrl(url: string) {
-    if (url.startsWith(PROXY_PREFIX)) {
+    if (PROXY_PREFIX.filter((proxy) => url.startsWith(proxy)).length > 0) {
         return "Plugin";
     } else if (url.endsWith(".json") && window.__vendetta_loader?.features.themes) {
         return "Theme";

--- a/src/ui/settings/data.tsx
+++ b/src/ui/settings/data.tsx
@@ -48,7 +48,7 @@ export const getScreens = (youKeys = false): Screen[] => [
                 <InstallButton
                     alertTitle="Install Plugin"
                     installFunction={async (input) => {
-                        if (!input.startsWith(PROXY_PREFIX) && !settings.developerSettings)
+                        if (!(PROXY_PREFIX.filter((proxy) => input.startsWith(proxy)).length > 0) && !settings.developerSettings)
                             setImmediate(() => showConfirmationAlert({
                                 title: "Unproxied Plugin",
                                 content: "The plugin you are trying to install has not been verified by Revenge staff. Are you sure you want to continue?",


### PR DESCRIPTION
`PROXY_PREFIX` is now an array that contains the proxies usable by default. URLs starting with one of those values are treated differently than others, allowing for quick installs (when in a message) and skipping the warning popup for unproxied plugins.

Note that this PR doesn't change the available proxies — the only default option is still the `vd-plugins.github.io` proxy.

Closes #5 