### PR TITLE
fix: use new invite link

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 // TODO: Replace links and constants with actual values
-export const DISCORD_SERVER = "https://discord.gg/n9QQ4XhhJP";
+export const DISCORD_SERVER = "https://discord.com/invite/ddcQf3s2Uq";
 export const DISCORD_SERVER_ID = "1015931589865246730";
 export const PLUGINS_CHANNEL_ID = "1091880384561684561";
 export const THEMES_CHANNEL_ID = "1091880434939482202";


### PR DESCRIPTION
Fixes revenge-mod/Revenge#14 by changing the invite link to a new one found in https://github.com/revenge-mod
