### PR TITLE
ci: use github actions bot instead actions user

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          path: main
+          path: "source"
 
       - name: Checkout builds
         uses: actions/checkout@v4
@@ -29,22 +29,24 @@ jobs:
       - uses: oven-sh/setup-bun@v1
 
       - name: Install dependencies
-        working-directory: main
+        working-directory: source
         run: bun i
 
       - name: CI
-        working-directory: main
+        working-directory: source
         run: bun run format
 
       - name: Build
-        working-directory: main
+        working-directory: source
         run: bun run build-bun
 
       - name: Push builds
         run: |
-          rm $GITHUB_WORKSPACE/builds/* || true
-          cp -r dist/* $GITHUB_WORKSPACE/builds || true
+          rm $GITHUB_WORKSPACE/builds/*
+          cp -r $GITHUB_WORKSPACE/source/dist/* $GITHUB_WORKSPACE/builds
           cd $GITHUB_WORKSPACE/builds
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
           git add .
           git commit -m "Build $GITHUB_SHA" || exit 0
           git push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,8 @@ jobs:
           rm $GITHUB_WORKSPACE/builds/*
           cp -r $GITHUB_WORKSPACE/source/dist/* $GITHUB_WORKSPACE/builds
           cd $GITHUB_WORKSPACE/builds
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           git add .
           git commit -m "Build $GITHUB_SHA" || exit 0
           git push


### PR DESCRIPTION
I know that this is unnecessary change but i think we can all agree that:

![image](https://github.com/revenge-mod/Revenge/assets/56601352/2539f2c5-f565-40f2-adee-8782ed70b28d)

looks better than

![image](https://github.com/revenge-mod/Revenge/assets/56601352/4c68dbd8-fd1a-4318-82c8-c6387cdc7990)
