### PR TITLE
Add new revenge proxy to `PROXY_PREFIXES`

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,7 +5,7 @@ export const PLUGINS_CHANNEL_ID = "1091880384561684561";
 export const THEMES_CHANNEL_ID = "1091880434939482202";
 export const GITHUB = "https://github.com/revenge-mod";
 export const PROXY_PREFIX = "https://vd-plugins.github.io/proxy";
-export const PROXY_PREFIXES = ["https://vd-plugins.github.io/proxy"];
+export const PROXY_PREFIXES = ["https://vd-plugins.github.io/proxy", "https://revenge-plugins.github.io/proxy"]];
 export const HTTP_REGEX =
   /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$/;
 export const HTTP_REGEX_MULTI =


### PR DESCRIPTION
This PR adds the new revenge proxy (<https://revenge-plugins.github.io/proxy>) to the
`PROXY_PREFIXES`.