### PR TITLE
Add 🍎 to readme for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This repository releases JavaScript bundles for loaders to execute. These are th
 
 ### iOS
 
-- [**RevengeTweak**](https://github.com/revenge-mod/revenge-tweak): Prebuilt rootful and rootless `.deb` files or the prepatched `.ipa`
+- 🍎 [**RevengeTweak**](https://github.com/revenge-mod/revenge-tweak): Prebuilt rootful and rootless `.deb` files or the prepatched `.ipa`
 
 ## 📚 Everything else
 


### PR DESCRIPTION
The README.md file, as it stands right now, lacks consistency, as the iOS option does not include an emoji, when the rest of them do. I have gone ahead and added a 🍎 to make the iOS option less left out of the group. I hope you accept my change. 
Sincerely, me.